### PR TITLE
ci(check): remove job check in ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,21 +5,6 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: wasm32-unknown-unknown
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   test:
     name: Test Suite
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

the `cargo check` can help us checking our local packages and all of its dependencies for errors which `cargo test` and `cargo clippy` have the same

The benefit of using `cargo check` is finding errors of our project as fast as possible in CI, but it is not reasonable enough for adding this as a job in CI since we should have already build pass our project on our local machine

## Tests

```
CI
```

## Issues

- Closes #44