### PR TITLE
Make use of unit type `()` as the value for Relayer and VerfiedBlocks

### DIFF
--- a/filecoindot/src/tests/vote.rs
+++ b/filecoindot/src/tests/vote.rs
@@ -91,7 +91,7 @@ fn submit_block_vote_resolve_rejected() {
             ),
             Error::<Test>::ProposalExpired
         );
-        assert!(!VerifiedBlocks::<Test>::get(&block_cid).unwrap());
+        assert!(!VerifiedBlocks::<Test>::contains_key(&block_cid));
         assert!(BlockSubmissionProposals::<Test>::get(&block_cid).is_none(),);
         assert!(MessageRootCidCounter::<Test>::get(&block_cid, &message_cid).is_none(),);
     });
@@ -118,7 +118,7 @@ fn submit_block_vote_resolve_approved() {
             message_cid.clone()
         ));
         // assert_eq!(*p.get_status(), ProposalStatus::Approved);
-        assert!(VerifiedBlocks::<Test>::get(&block_cid).unwrap());
+        assert!(VerifiedBlocks::<Test>::contains_key(&block_cid));
         // assert_eq!(BlockSubmissionProposals::<Test>::get(&block_cid).is_none(), true);
         assert!(MessageRootCidCounter::<Test>::get(&block_cid, &message_cid).is_none(),);
     });
@@ -154,7 +154,7 @@ fn submit_block_vote_resolve_completed() {
             ),
             Error::<Test>::BlockAlreadyVerified
         );
-        assert!(VerifiedBlocks::<Test>::get(&block_cid).unwrap());
+        assert!(VerifiedBlocks::<Test>::contains_key(&block_cid));
         assert!(BlockSubmissionProposals::<Test>::get(&block_cid).is_none(),);
         assert!(MessageRootCidCounter::<Test>::get(&block_cid, &message_cid).is_none(),);
     });
@@ -186,7 +186,7 @@ fn close_block_proposal_already_verified() {
             FileCoinModule::close_block_proposal(Origin::signed(ALICE), block_cid.clone()),
             Error::<Test>::BlockAlreadyVerified
         );
-        assert!(VerifiedBlocks::<Test>::get(&block_cid).unwrap());
+        assert!(VerifiedBlocks::<Test>::contains_key(&block_cid));
         assert!(BlockSubmissionProposals::<Test>::get(&block_cid).is_none(),);
         assert!(MessageRootCidCounter::<Test>::get(&block_cid, &message_cid).is_none(),);
     });
@@ -228,7 +228,7 @@ fn close_block_proposal_works() {
             block_cid.clone(),
         ));
         assert!(
-            !VerifiedBlocks::<Test>::get(&block_cid).unwrap(),
+            !VerifiedBlocks::<Test>::contains_key(&block_cid),
             "{}",
             false
         );


### PR DESCRIPTION
which essentially convert them into substrate way of using `Set` instead of
`Map` with boolean values.

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Relayer storage value from `bool` to `()`
- VerfiedBlocks storage value from `bool` to `()`

```rust
fn main(){
    println!("size of bool:{}", std::mem::size_of::<bool>());
    println!("size of ():{}", std::mem::size_of::<()>());
}
```
```log
size of bool:1
size of ():0
```
The value stored is essentially zero size, but it's up to the underlying database storage of substrate whether this would decrease (even for a little bit) the size of the data being stored.
## Tests
Just run the existing tests
```
cargo test
cargo test --release
```
<!--

Details on how to run tests relevant to the changes within this pull request.

-->


## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #72