### PR TITLE
refactor(types)!: move the field 'voted' from BlockSubmissionProposal struct into a new storage map

### DIFF
--- a/filecoindot/src/types.rs
+++ b/filecoindot/src/types.rs
@@ -12,8 +12,6 @@ use crate::{pallet, Config, Error, MessageRootCidCounter, Relayers};
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 pub(crate) struct BlockSubmissionProposal<T: Config> {
     proposer: T::AccountId,
-    /// The accounts with voted
-    voted: BTreeSet<T::AccountId>,
     /// The status of the proposal
     status: ProposalStatus,
     /// The block number that the proposal started
@@ -30,7 +28,7 @@ impl<T: Config> BlockSubmissionProposal<T> {
     ) -> Self {
         BlockSubmissionProposal {
             proposer,
-            voted: BTreeSet::new(),
+            //voted: BTreeSet::new(),
             status: ProposalStatus::Active,
             start_block,
             end_block,
@@ -42,39 +40,8 @@ impl<T: Config> BlockSubmissionProposal<T> {
         &self.status
     }
 
-    /// Vote for the proposal. Will reject the operation if its status is invalid
-    /// The content of the vote is actually the message root of the block
-    pub fn vote(
-        &mut self,
-        block_cid: pallet::BlockCid,
-        message_root: pallet::MessageRootCid,
-        who: T::AccountId,
-        when: &T::BlockNumber,
-        threshold: u32,
-    ) -> Result<(), Error<T>> {
-        ensure!(!self.is_voted(&who), Error::<T>::AlreadyVoted);
-        ensure!(
-            self.status == ProposalStatus::Active,
-            Error::<T>::ProposalCompleted
-        );
-
-        // when expired, we set the status to be rejected
-        if self.is_expired(when) {
-            self.status = ProposalStatus::Rejected;
-            return Err(Error::<T>::ProposalExpired);
-        }
-
-        // MessageRootCidCounter leaked into the struct, well not the best way for encapsulation
-        // but works for now, come back later to fix this.
-        let count = 1 + MessageRootCidCounter::<T>::get(&block_cid, &message_root).unwrap_or(0);
-        if count >= threshold {
-            self.status = ProposalStatus::Approved;
-        }
-
-        MessageRootCidCounter::<T>::insert(&block_cid, &message_root, count);
-        self.voted.insert(who);
-
-        Ok(())
+    pub fn set_status(&mut self, new_status: ProposalStatus) {
+        self.status = new_status;
     }
 
     /// Resolve the proposal status
@@ -106,13 +73,8 @@ impl<T: Config> BlockSubmissionProposal<T> {
         Ok(())
     }
 
-    /// Checks if the account has already voted
-    fn is_voted(&self, who: &T::AccountId) -> bool {
-        self.voted.contains(who)
-    }
-
     /// Whether the proposal is still active, i.e. can vote
-    fn is_expired(&self, now: &T::BlockNumber) -> bool {
+    pub(crate) fn is_expired(&self, now: &T::BlockNumber) -> bool {
         now.gt(&self.end_block)
     }
 }

--- a/filecoindot/src/types.rs
+++ b/filecoindot/src/types.rs
@@ -3,10 +3,9 @@
 
 use frame_support::pallet_prelude::*;
 use frame_support::sp_std;
-use frame_support::sp_std::collections::btree_set::BTreeSet;
 use frame_system::{Origin, RawOrigin};
 
-use crate::{pallet, Config, Error, MessageRootCidCounter, Relayers};
+use crate::{Config, Error, MessageRootCidCounter, Relayers};
 
 /// The filecoin block submission proposal
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]

--- a/filecoindot/src/types.rs
+++ b/filecoindot/src/types.rs
@@ -74,7 +74,7 @@ impl<T: Config> BlockSubmissionProposal<T> {
     }
 
     /// Whether the proposal is still active, i.e. can vote
-    pub(crate) fn is_expired(&self, now: &T::BlockNumber) -> bool {
+    pub fn is_expired(&self, now: &T::BlockNumber) -> bool {
         now.gt(&self.end_block)
     }
 }


### PR DESCRIPTION
called `BlockProposalVotes`.

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- A new storage double map called `BlockProposalVotes` is created to store an entry of `(BlockNumber, AccountId, ())` this tracks the list accounts which voted for a particular submitted Block proposal
- the logic code from `vote` method in `BlockSubmissionProposal` shifted into filecoindot pallet's method `vote_block_proposal`.
- A new method `set_status` is added to `BlockSubmissionProposal` to allow changes to it's status being called from the pallet's runtime.
- The visibility of `is_expired` method from `BlockSubmissionProposal` is now `pub` to allow calling it from the pallet's runtime.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
- cargo test --release
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Issue #73 