### PR TITLE
doc(rpc): update curl params for setting rpc endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ curl -X POST -H "Content-type: application/json"  http://localhost:9933 -d '
 {
   "method": "filecoindot_setRpcEndpoint",
   "jsonrpc": "2.0",
-  "params": { "urls": ["https://api.node.glif.io"] }
+  "id": 0,
+  "params": [ ["https://api.node.glif.io"] ]
 }
 '
 ```


### PR DESCRIPTION
## Changes

- update outdated setting rpc params

## Tests

```sh
# run this after bootstrap fliecoindot-template
curl -X POST -H "Content-type: application/json"  http://localhost:9933 -d '
{
  "method": "filecoindot_setRpcEndpoint",
  "jsonrpc": "2.0",
  "id": 0,
  "params": [ ["https://api.node.glif.io"] ]
}
'
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-