### PR TITLE
fix(docker): update-ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /pint pint && \
     mkdir /data && \
     chown -R pint:pint /data && \
     ln -s /data /pint/.local/share/filecoindot-template && \
-    rm -rf /usr/bin /usr/sbin
+    rm -rf /usr/bin /usr/sbin \
+RUN update-ca-certificates
 USER pint
 # 30333 for p2p traffic
 # 9933 for RPC call

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /pint pint && \
     mkdir /data && \
     chown -R pint:pint /data && \
     ln -s /data /pint/.local/share/filecoindot-template && \
-    rm -rf /usr/bin /usr/sbin \
+    rm -rf /usr/bin /usr/sbin
 RUN update-ca-certificates
 USER pint
 # 30333 for p2p traffic


### PR DESCRIPTION
should prevent crash

```shell
Thread 'tokio-runtime-worker' panicked at 'no CA certificates found', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-rustls-0.22.1/src/connector.rs:45
```