### PR TITLE
chore(js): include source-map in js packages

### DIFF
--- a/js/e2e/package.json
+++ b/js/e2e/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@filecoindot/e2e",
-  "version": "0.1.15",
+  "version": "0.1.20",
   "description": "e2e testing for filecoindot",
   "main": "index.js",
+  "files": [
+    "lib/*"
+  ],
   "repository": "https://github.com/chainSafe/filecoindot/",
   "author": "clearloop",
   "license": "MIT",
   "dependencies": {
-    "@chainsafe/filecoindot-types": "0.1.15",
+    "@chainsafe/filecoindot-types": "0.1.20",
     "@polkadot/api": "^6.9.2",
     "@polkadot/keyring": "^8.2.2",
     "@polkadot/types": "^6.9.2",

--- a/js/types/package.json
+++ b/js/types/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@chainsafe/filecoindot-types",
-  "version": "0.1.15",
+  "version": "0.1.20",
   "description": "Types bundle for filecoindot",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "lib/*"
+  ],
   "author": "tianyi@chainsafe.io",
   "license": "MIT",
   "publishConfig": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "js/*"
   ],
-  "version": "0.1.15"
+  "version": "0.1.20"
 }


### PR DESCRIPTION
## Changes

in case of the warning of importing `@chainsafe/filecoindot-types` in react app, we need to pack sourcemap into our npm packages


> NOTE: since we only trigger `npm publish` on release or tagging, published on my local machine, sync the modification

## Tests


`@chainsafe/filecoindot-types@v0.1.20`

## Issues

-