### PR TITLE
refactor: use a more terse function contains_key to check if the account_id is a relayer

### DIFF
--- a/filecoindot/src/lib.rs
+++ b/filecoindot/src/lib.rs
@@ -471,7 +471,7 @@ pub mod pallet {
 
         /// Checks if who is a relayer
         fn is_relayer(who: &T::AccountId) -> bool {
-            Relayers::<T>::get(who).map(|_| true).unwrap_or(false)
+            Relayers::<T>::contains_key(who)
         }
 
         // ============== Voting Related =============


### PR DESCRIPTION

## Changes
use the appropriate function `contains_key` for checking the account_id in the map-set.

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->


## Tests

```sh
cargo test --all
```
<!--

Details on how to run tests relevant to the changes within this pull request.

-->


## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->
